### PR TITLE
feat: added migrations directory & binary in container so it can be used to bootstrap db

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM golang:1.25.0 AS build
-
 WORKDIR /build
 COPY go.mod .
 COPY go.sum .
@@ -7,11 +6,26 @@ RUN go mod download
 COPY . .
 RUN go build -o nodebot
 
-FROM alpine:3.22.1
+FROM debian:trixie-20250929-slim AS migrate
+ARG CURL_VERSION="8.*"
+ARG GOMIGRATE_VERSION="v4.19.0"
+WORKDIR /build
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        curl=${CURL_VERSION}
+RUN ARCH="$(dpkg --print-architecture)" && \
+  curl -sL "https://github.com/golang-migrate/migrate/releases/download/${GOMIGRATE_VERSION}/migrate.linux-${ARCH}.tar.gz" -o migrate.tar.gz
+RUN tar -xzf migrate.tar.gz
 
+
+FROM alpine:3.22.1
 ARG GCOMPAT_VERSION="1.1.0-r4"
 RUN apk add --no-cache gcompat=${GCOMPAT_VERSION} && \
       rm -rf /var/cache/apk/*
 WORKDIR /app
 COPY --from=build /build/nodebot nodebot
+WORKDIR /migrations
+COPY --from=build /build/internal/db/migrations migrations
+COPY --from=migrate /build/migrate /usr/local/bin/migrate
+
 ENTRYPOINT ["/app/nodebot"]

--- a/Makefile
+++ b/Makefile
@@ -27,4 +27,4 @@ setup:
 	podman compose up -d
 
 migrate:
-	podman run -v $(PWD)/internal/db/migrations:/migrations --network host migrate/migrate:v4.19.0 -path=/migrations/ -database postgres://postgres:password@localhost:5432/nodebot up
+	podman run -v $(PWD)/internal/db/migrations:/migrations --network host migrate/migrate:v4.19.0 -path=/migrations/ -database postgres://postgres:password@localhost:5432/nodebot?sslmode=disable up


### PR DESCRIPTION
# Why ?

When trying to deploy the bot to k8s I realized that we need a way to play migrations before the bot spawns. I thought of using the migrate container directly but mounting the migration files would've been a pain. With this PR we bundle the CLI and the migrations files in the container which means we can use this image to spawn initContainers and prevent the bot from spawning if the migration fails.